### PR TITLE
Added option for GCM sender ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ inspector/ios-inspector/ForgeModule/build
 inspector/ios-inspector/ForgeModule/ForgeModule.xcodeproj
 inspector/ios-inspector/build
 .idea
+.project
 **/*.iml
 inspector/an-inspector/out
 inspector/an-inspector/ForgeModule/gen

--- a/module/android/build_steps.json
+++ b/module/android/build_steps.json
@@ -53,6 +53,19 @@
 			}
 		}
 	},
+	{
+		"do": {
+			"android_add_to_application_manifest": {
+				"element": {
+					"tag": "meta-data",
+					"attributes": {
+						"android:name": "com.parse.push.gcm_sender_id",
+						"android:resource": "id:{{modules.parse.config.android.GCMsenderID}}"
+					}
+				}
+			}
+		}
+	},
 
 	{
 		"do": {

--- a/module/android/build_steps.json
+++ b/module/android/build_steps.json
@@ -60,7 +60,7 @@
 					"tag": "meta-data",
 					"attributes": {
 						"android:name": "com.parse.push.gcm_sender_id",
-						"android:resource": "id:{{modules.parse.config.android.GCMsenderID}}"
+						"android:value": "id:{{modules.parse.config.android.GCMsenderID}}"
 					}
 				}
 			}

--- a/module/config_schema.json
+++ b/module/config_schema.json
@@ -38,15 +38,22 @@
 			"additionalProperties": false,
 			"description": "Android specific settings",
 			"properties": {
+				"GCMsenderID": {
+					"_order": 10,
+					"required": false,
+					"description": "One or multiple (comma-seperated) own GCM sender IDs to be used for GCM registration.",
+					"type": "string",
+					"title": "GCM sender ID"
+				},
 				"updateNotifications": {
-					"_order": 1,
+					"_order": 20,
 					"required": false,
 					"description": "Update notifications on Android, includes a message counter",
 					"type": "boolean",
 					"title": "Update Notifications"
 				},
 				"background-color": {
-					"_order": 2,
+					"_order": 30,
                     "type": "string",
                     "required": false,
                     "description": "Use a custom color for the background for your notification icon, e.g. #303045. Android 5.0+ only.",
@@ -54,7 +61,7 @@
 					"title": "Background Color"
                 },
 				"notification_icon": {
-					"_order": 10,
+					"_order": 40,
                     "type": "string",
                     "required": true,
                     "title": "Notification Icon",
@@ -62,31 +69,31 @@
                     "enum": [ "icon", "custom_push_icon" ]
                 },
 				"24": {
-					"_order": 11,
+					"_order": 41,
 					"required": false,
 					"type": "string",
 					"_filepicker": true
 				},
 				"36": {
-					"_order": 12,
+					"_order": 42,
 					"required": false,
 					"type": "string",
 					"_filepicker": true
 				},
 				"48": {
-					"_order": 13,
+					"_order": 43,
 					"required": false,
 					"type": "string",
 					"_filepicker": true
 				},
 				"72": {
-					"_order": 14,
+					"_order": 44,
 					"required": false,
 					"type": "string",
 					"_filepicker": true
 				},
 				"96": {
-					"_order": 15,
+					"_order": 45,
 					"required": false,
 					"type": "string",
 					"_filepicker": true

--- a/module/docs/index.md
+++ b/module/docs/index.md
@@ -27,8 +27,11 @@ delayRegistration
 
 ###Android
 
+GCM sender ID
+:   Use one or multiple (comma-seperated) own GCM sender IDs that will be used in addition to Parse's own sender ID during GCM registration. (Optional: use when migrating away from Parse or pushing from multiple providers. [More information.](https://github.com/ParsePlatform/parse-server/wiki/Compatibility-with-Hosted-Parse#android-exporting-gcm-registration-ids))
+
 Update Notifications
-:    Update notifications on Android using the Inbox Style. This option also suppresses notification display on Android while the app is visible.  [More information.](https://blog.safaribooksonline.com/2012/08/29/android-4-1-jelly-bean-notifications/)
+:   Update notifications on Android using the Inbox Style. This option also suppresses notification display on Android while the app is visible.  [More information.](https://blog.safaribooksonline.com/2012/08/29/android-4-1-jelly-bean-notifications/)
 
 Background Color
 :   Use a custom color for the background for your notification icon, e.g. #303045. (Android 5.0+ only)

--- a/module/manifest.json
+++ b/module/manifest.json
@@ -1,9 +1,9 @@
 {
-	"changes": "* Updated Parse Android and iOS SDK to v1.13.1 supporting self-hosted Parse Servers.\n* Removed Facebook dependency",
+	"changes": "* Added option to set a own GCM sender ID to be used during GCM registration.",
 	"dependencies": {},
 	"description": "Parse.com configuration to enable push notifications.\n\nThe parse module uses the Parse.com SDK to allow for native push notifications.",
 	"min_platform_version": "v2.4.5",
 	"namespace": "parse",
 	"platform_version": "v2.4.5",
-	"version": "2.13"
+	"version": "2.14"
 }


### PR DESCRIPTION
Use one or multiple (comma-seperated) own GCM sender IDs that will be used in addition to Parse's own sender ID during GCM registration. (Optional: use when migrating away from Parse or pushing from multiple providers. [More information.](https://github.com/ParsePlatform/parse-server/wiki/Compatibility-with-Hosted-Parse#android-exporting-gcm-registration-ids))