### PR TITLE
Explicit setting to show notifications on Android while app is visible in foreground

### DIFF
--- a/inspector/an-inspector/ForgeModule/src/com/parse/ForgePushBroadcastReceiver.java
+++ b/inspector/an-inspector/ForgeModule/src/com/parse/ForgePushBroadcastReceiver.java
@@ -26,6 +26,7 @@ import io.trigger.forge.android.modules.parse.Constant;
 
 public class ForgePushBroadcastReceiver extends ParsePushBroadcastReceiver {
     private static final String UPDATE_NOTIFICATIONS_FEATURE = "updateNotifications";
+    private static final String SHOW_NOTIFICATIONS_WHILE_VISIBLE = "showNotificationsWhileVisible";
 
     private static final String notificationChannelId = "default";
     private static final String notificationChannelDescription = "Default";
@@ -38,6 +39,14 @@ public class ForgePushBroadcastReceiver extends ParsePushBroadcastReceiver {
         return config.has("android") &&
                config.getAsJsonObject("android").has(UPDATE_NOTIFICATIONS_FEATURE) &&
                config.getAsJsonObject("android").get(UPDATE_NOTIFICATIONS_FEATURE).getAsBoolean();
+    }
+
+    private boolean showNotificationsWhileVisible() {
+        JsonObject config = ForgeApp.configForModule(Constant.MODULE_NAME);
+
+        return config.has("android") &&
+                config.getAsJsonObject("android").has(SHOW_NOTIFICATIONS_WHILE_VISIBLE) &&
+                config.getAsJsonObject("android").get(SHOW_NOTIFICATIONS_WHILE_VISIBLE).getAsBoolean();
     }
 
     private Notification setBackgroundColor(Notification notification) {
@@ -80,14 +89,16 @@ public class ForgePushBroadcastReceiver extends ParsePushBroadcastReceiver {
 
     @Override
     protected Notification getNotification(Context context, Intent intent) {
-        if (!isUpdateNotificationsFeature()) {
-            return setBackgroundColor(super.getNotification(context, intent));
-        } else if (VisibilityManager.isVisible()) {
+        if (VisibilityManager.isVisible() && !showNotificationsWhileVisible()) {
             return null;
-        } else {
+        }
+
+        if (isUpdateNotificationsFeature()) {
             buildAndShowUpdatableNotification(context, intent);
             return null;
         }
+
+        return setBackgroundColor(super.getNotification(context, intent));
     }
 
     protected void buildAndShowUpdatableNotification(Context context, Intent intent) {

--- a/module/config_schema.json
+++ b/module/config_schema.json
@@ -52,6 +52,13 @@
 					"type": "boolean",
 					"title": "Update Notifications"
 				},
+				"showNotificationsWhileVisible": {
+					"_order": 21,
+					"required": false,
+					"description": "Show incoming notifications on Android, even if the app is currently visible in foreground.",
+					"type": "boolean",
+					"title": "Show Notifications While Visible"
+				},
 				"background-color": {
 					"_order": 30,
 					"type": "string",

--- a/module/docs/index.md
+++ b/module/docs/index.md
@@ -31,7 +31,10 @@ GCM sender ID
 :   Use one or multiple (comma-seperated) own GCM sender IDs that will be used in addition to Parse's own sender ID during GCM registration. (Optional: use when migrating away from Parse or pushing from multiple providers. [More information.](https://github.com/ParsePlatform/parse-server/wiki/Compatibility-with-Hosted-Parse#android-exporting-gcm-registration-ids))
 
 Update Notifications
-:   Update notifications on Android using the Inbox Style. This option also suppresses notification display on Android while the app is visible.  [More information.](https://blog.safaribooksonline.com/2012/08/29/android-4-1-jelly-bean-notifications/)
+:   Update notifications on Android using the Inbox Style.  [More information.](https://blog.safaribooksonline.com/2012/08/29/android-4-1-jelly-bean-notifications/)
+
+Show Notifications While Visible
+:   Show incoming notifications on Android, even if the app is currently visible in foreground. Default is to not show them in this case.
 
 Background Color
 :   Use a custom color for the background for your notification icon, e.g. #303045. (Android 5.0+ only)

--- a/module/inspector_config.json
+++ b/module/inspector_config.json
@@ -13,7 +13,8 @@
                 "notification_icon": "custom_push_icon",
                 "background-color": "#5555ff",
                 "GCMsenderID": "677378418801",
-                "updateNotifications": true
+                "updateNotifications": true,
+                "showNotificationsWhileVisible": false
             }
         }
     },

--- a/module/manifest.json
+++ b/module/manifest.json
@@ -1,5 +1,5 @@
 {
-    "changes": "* Updated Parse Android SDK to 1.16.3\n",
+    "changes": "* Added explicit setting to show notifications on Android while app is visible in foreground.",
     "dependencies": {
         "bolts": {
             "minimum_version": "1.6.0",
@@ -7,8 +7,8 @@
         }
     },
     "description": "Parse.com configuration to enable push notifications.\n\nThe parse module uses the Parse.com SDK to allow for native push notifications.",
-    "min_platform_version": "v2.6.1",
+    "min_platform_version": "v2.6.6",
     "namespace": "parse",
-    "platform_version": "v2.6.1",
-    "version": "2.17.1"
+    "platform_version": "v2.6.6",
+    "version": "2.18"
 }


### PR DESCRIPTION
This PR adds an explicit setting for the handling to show notifications on Android depending on app visibility. So far this was included in the "updateNotifications" option to not show notifications if app is visible in case "updateNotifications" is set to true. Those two settings are now independent from each other.

This introduces small breaking change depending on what configuration is used. By default "updateNotifications" is false if not set and therefore notifications were shown in foreground on Android before this PR. Now notifications are not shown unless the setting "showNotificationsWhileVisible" is explicitly set to true. Unfortunately it is not able to prevent this breaking change, as changing the default would just mean the opposite outcome and therefore a breaking change when using "updateNotifications=true". @antoinevg I guess it's up to you, maybe you have usage statistics on how many customers use the updateNotifications flag, so you could minimize the breakage to the smaller portion?

Ofc feel free to adjust naming if it doesn't fit :)